### PR TITLE
Improve response transformation async behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "@biothings-explorer/api-response-transform",
       "version": "1.12.0",
       "license": "ISC",
       "dependencies": {
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
+        "async": "^3.2.1",
         "axios": "^0.21.1",
         "common-path-prefix": "^3.0.0",
         "husky": "^4.3.8",
@@ -18,6 +18,7 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
+        "@types/async": "^3.2.8",
         "@types/lodash": "^4.14.168",
         "coveralls": "^3.1.0",
         "debug": "^4.3.1",
@@ -1089,6 +1090,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@types/async": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.8.tgz",
+      "integrity": "sha512-1vvBNUF6mY6Px8MZIJoTbCI8h06N9jkIFGbLxaVJk9nX11TlnojrzUoN3MyRgqw5pL67+eV3MUvPX7PqjM5Wbg==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.14",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -1443,6 +1450,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
+      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -9599,6 +9611,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/async": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.8.tgz",
+      "integrity": "sha512-1vvBNUF6mY6Px8MZIJoTbCI8h06N9jkIFGbLxaVJk9nX11TlnojrzUoN3MyRgqw5pL67+eV3MUvPX7PqjM5Wbg==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.14",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -9891,6 +9909,11 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
+    },
+    "async": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
+      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/biothings/api-respone-transform.js#readme",
   "devDependencies": {
+    "@types/async": "^3.2.8",
     "@types/lodash": "^4.14.168",
     "coveralls": "^3.1.0",
     "debug": "^4.3.1",
@@ -42,10 +43,11 @@
   "dependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
+    "async": "^3.2.1",
     "axios": "^0.21.1",
+    "common-path-prefix": "^3.0.0",
     "husky": "^4.3.8",
     "jsonata": "^1.8.4",
-    "common-path-prefix": "^3.0.0",
     "lodash": "^4.17.21"
   },
   "husky": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export class Transformer {
         }
     }
 
-    transform() {
-        return this.tf.transform();
+    async transform() {
+        return await this.tf.transform();
     }
 }

--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -8,176 +8,176 @@ import async from "async";
 const debug = Debug("bte:api-response-transform:transformer");
 
 export default class BaseTransformer {
-  protected edge: BTEKGOperationObject;
-  protected data: BTEQueryObject;
+    protected edge: BTEKGOperationObject;
+    protected data: BTEQueryObject;
 
-  constructor(data: BTEQueryObject) {
-    this.data = data;
-    this.edge = data.edge;
-  }
-
-  /**
-   * Create an object with key representing input, and value representing the output of API
-   */
-  pairInputWithAPIResponse() {
-    let input = generateCurie(this.edge.association.input_id, this.edge.input);
-    return {
-      [input]: [this.data.response],
-    };
-  }
-
-  /**
-   * Wrapper functions to transform API response before passing to JSON Transformer
-   * @return {Object} - key is curie representing input, value is an array of outputs.
-   */
-  wrap(res) {
-    if (Array.isArray(res)) {
-      res = { data: res };
+    constructor(data: BTEQueryObject) {
+        this.data = data;
+        this.edge = data.edge;
     }
-    return res;
-  }
 
-  /**
-   * Transform Individual JSON response into Biolink compatible format
-   * @param {Object} res - JSON response representing an output.
-   */
-  jsonTransform(res: JSONDoc | JSONDoc[]) {
-    res = transform(res, this.edge.response_mapping);
-    return res;
-  }
-
-  _updatePublications(res) {
-    if ("pubmed" in res) {
-      res.pubmed = toArray(res.pubmed);
-      res.publications = res.pubmed.map(item =>
-        typeof item === "string" && item.toUpperCase().startsWith("PMID:") ? item.toUpperCase() : "PMID:" + item,
-      );
-      delete res.pubmed;
-    }
-    if ("pmc" in res) {
-      res.pmc = toArray(res.pmc);
-      res.publications = res.pmc.map(item =>
-        typeof item === "string" && item.toUpperCase().startsWith("PMC:") ? item.toUpperCase() : "PMC:" + item,
-      );
-      delete res.pmc;
-    }
-    return res;
-  }
-
-  _updateEdgeMetadata(res) {
-    res.$edge_metadata = {
-      ...this.edge.association,
-      trapi_qEdge_obj: this.edge.reasoner_edge,
-      filter: this.edge.filter,
-    };
-    return res;
-  }
-
-  _updateInput(res, input) {
-    debug(`input: ${input}`);
-    res.$input = {
-      original: typeof this.edge.original_input === "undefined" ? undefined : this.edge.original_input[input],
-      obj:
-        typeof this.edge.input_resolved_identifiers === "undefined" || typeof this.edge.original_input === "undefined"
-          ? undefined
-          : this.edge.input_resolved_identifiers[this.edge.original_input[input]],
-    };
-    if (this.edge.input_resolved_identifiers && res.$input.original === undefined && res.$input.obj === undefined) {
-      //try to find an equivalent ids object if the original input doesn't match (for ICEES)
-      for (let curie of Object.keys(this.edge.input_resolved_identifiers)) {
-        if (this.edge.input_resolved_identifiers[curie][0].curies.includes(input)) {
-          res.$input = {
-            original: curie,
-            obj: this.edge.input_resolved_identifiers[curie],
-          };
-          break;
-        }
-      }
-    }
-    return res;
-  }
-
-  _removeNonEdgeData(res) {
-    delete res["@type"];
-    delete res[this.edge.association.output_id];
-    return res;
-  }
-
-  /**
-   * Add edge information into individual output JSON.
-   * @param {Object} res - JSON response representing an output.
-   */
-  async addEdgeInfo(input, res) {
-    if (res === undefined || Object.keys(res).length === 0) {
-        return [];
-    }
-    res = this._updateEdgeMetadata(res);
-    res = this._updateInput(res, input);
-    const output_ids = this.extractOutputIDs(res);
-
-    const setImmediatePromise = () => {
-        return new Promise((resolve: any) => {
-            setImmediate(() => resolve());
-        });
-    };
-
-    let result = await async.mapSeries(output_ids, async item => {
-        let blockingSince = Date.now();
-
-        let copy_res = _.cloneDeep(res);
-        if (blockingSince + 3 < Date.now()) {
-            await setImmediatePromise();
-            blockingSince = Date.now();
-        }
-        copy_res.$edge_metadata = res.$edge_metadata;
-        copy_res.$output = {
-            original: item,
+    /**
+     * Create an object with key representing input, and value representing the output of API
+     */
+    pairInputWithAPIResponse() {
+        let input = generateCurie(this.edge.association.input_id, this.edge.input);
+        return {
+            [input]: [this.data.response],
         };
-        copy_res = this._removeNonEdgeData(copy_res);
-        copy_res = this._updatePublications(copy_res);
-        return copy_res;
-    });
-    return result;
-  }
+    }
 
-  /**
-   * Main function to transform API response
-   */
-  async transform() {
-    let result = [];
-    let responses = this.pairInputWithAPIResponse();
+    /**
+     * Wrapper functions to transform API response before passing to JSON Transformer
+     * @return {Object} - key is curie representing input, value is an array of outputs.
+     */
+    wrap(res) {
+        if (Array.isArray(res)) {
+            res = { data: res };
+        }
+        return res;
+    }
 
-    await async.eachSeries(Object.keys(responses), async curie => {
-    if (Array.isArray(responses[curie]) && responses[curie].length > 0) {
-        await async.eachSeries(responses[curie], async item => {
-        item = this.wrap(item);
-        item = this.jsonTransform(item);
-        await async.eachSeries(Object.keys(item), async predicate => {
-            if (Array.isArray(item[predicate]) && item[predicate].length > 0) {
-            await async.eachSeries(item[predicate], async (rec: any[]) => {
-                rec = await this.addEdgeInfo(curie, rec);
-                result.push(...rec);
-            });
-            } else {
-                result.push(...(await this.addEdgeInfo(curie, item[predicate])));
+    /**
+     * Transform Individual JSON response into Biolink compatible format
+     * @param {Object} res - JSON response representing an output.
+     */
+    jsonTransform(res: JSONDoc | JSONDoc[]) {
+        res = transform(res, this.edge.response_mapping);
+        return res;
+    }
+
+    _updatePublications(res) {
+        if ("pubmed" in res) {
+            res.pubmed = toArray(res.pubmed);
+            res.publications = res.pubmed.map(item =>
+                typeof item === "string" && item.toUpperCase().startsWith("PMID:") ? item.toUpperCase() : "PMID:" + item,
+            );
+            delete res.pubmed;
+        }
+        if ("pmc" in res) {
+            res.pmc = toArray(res.pmc);
+            res.publications = res.pmc.map(item =>
+                typeof item === "string" && item.toUpperCase().startsWith("PMC:") ? item.toUpperCase() : "PMC:" + item,
+            );
+            delete res.pmc;
+        }
+        return res;
+    }
+
+    _updateEdgeMetadata(res) {
+        res.$edge_metadata = {
+            ...this.edge.association,
+            trapi_qEdge_obj: this.edge.reasoner_edge,
+            filter: this.edge.filter,
+        };
+        return res;
+    }
+
+    _updateInput(res, input) {
+        debug(`input: ${input}`);
+        res.$input = {
+        original: typeof this.edge.original_input === "undefined" ? undefined : this.edge.original_input[input],
+        obj:
+            typeof this.edge.input_resolved_identifiers === "undefined" || typeof this.edge.original_input === "undefined"
+            ? undefined
+            : this.edge.input_resolved_identifiers[this.edge.original_input[input]],
+        };
+        if (this.edge.input_resolved_identifiers && res.$input.original === undefined && res.$input.obj === undefined) {
+        //try to find an equivalent ids object if the original input doesn't match (for ICEES)
+        for (let curie of Object.keys(this.edge.input_resolved_identifiers)) {
+            if (this.edge.input_resolved_identifiers[curie][0].curies.includes(input)) {
+            res.$input = {
+                original: curie,
+                obj: this.edge.input_resolved_identifiers[curie],
+            };
+            break;
             }
-        });
-        });
+        }
+        }
+        return res;
     }
-    });
-    return result;
-  }
 
-  /**
-   * Retrieve all output IDs.
-   * @param {Object} res - JSON response representing an output.
-   */
-  extractOutputIDs(res) {
-    const output_id_type = this.edge.association.output_id;
-    if (!(output_id_type in res)) {
-      return [];
+    _removeNonEdgeData(res) {
+        delete res["@type"];
+        delete res[this.edge.association.output_id];
+        return res;
     }
-    res[output_id_type] = toArray(res[output_id_type]);
-    return res[output_id_type].map(item => generateCurie(output_id_type, item));
-  }
+
+    /**
+     * Add edge information into individual output JSON.
+     * @param {Object} res - JSON response representing an output.
+     */
+    async addEdgeInfo(input, res) {
+        if (res === undefined || Object.keys(res).length === 0) {
+            return [];
+        }
+        res = this._updateEdgeMetadata(res);
+        res = this._updateInput(res, input);
+        const output_ids = this.extractOutputIDs(res);
+
+        const setImmediatePromise = () => {
+            return new Promise((resolve: any) => {
+                setImmediate(() => resolve());
+            });
+        };
+
+        let result = await async.mapSeries(output_ids, async item => {
+            let blockingSince = Date.now();
+
+            let copy_res = _.cloneDeep(res);
+            if (blockingSince + 3 < Date.now()) {
+                await setImmediatePromise();
+                blockingSince = Date.now();
+            }
+            copy_res.$edge_metadata = res.$edge_metadata;
+            copy_res.$output = {
+                original: item,
+            };
+            copy_res = this._removeNonEdgeData(copy_res);
+            copy_res = this._updatePublications(copy_res);
+            return copy_res;
+        });
+        return result;
+    }
+
+    /**
+     * Main function to transform API response
+     */
+    async transform() {
+        let result = [];
+        let responses = this.pairInputWithAPIResponse();
+
+        await async.eachSeries(Object.keys(responses), async curie => {
+        if (Array.isArray(responses[curie]) && responses[curie].length > 0) {
+            await async.eachSeries(responses[curie], async item => {
+            item = this.wrap(item);
+            item = this.jsonTransform(item);
+            await async.eachSeries(Object.keys(item), async predicate => {
+                if (Array.isArray(item[predicate]) && item[predicate].length > 0) {
+                await async.eachSeries(item[predicate], async (rec: any[]) => {
+                    rec = await this.addEdgeInfo(curie, rec);
+                    result.push(...rec);
+                });
+                } else {
+                    result.push(...(await this.addEdgeInfo(curie, item[predicate])));
+                }
+            });
+            });
+        }
+        });
+        return result;
+    }
+
+    /**
+     * Retrieve all output IDs.
+     * @param {Object} res - JSON response representing an output.
+     */
+    extractOutputIDs(res) {
+        const output_id_type = this.edge.association.output_id;
+        if (!(output_id_type in res)) {
+            return [];
+        }
+        res[output_id_type] = toArray(res[output_id_type]);
+        return res[output_id_type].map(item => generateCurie(output_id_type, item));
+    }
 }

--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -1,160 +1,183 @@
 import { transform } from "../json_transform/index";
 import { JSONDoc } from "../json_transform/types";
-import { generateCurie, toArray } from '../utils';
+import { generateCurie, toArray } from "../utils";
 import { BTEKGOperationObject, BTEQueryObject } from "../types";
 import * as _ from "lodash";
 import Debug from "debug";
+import async from "async";
 const debug = Debug("bte:api-response-transform:transformer");
 
-
 export default class BaseTransformer {
-    protected edge: BTEKGOperationObject;
-    protected data: BTEQueryObject;
+  protected edge: BTEKGOperationObject;
+  protected data: BTEQueryObject;
 
-    constructor(data: BTEQueryObject) {
-        this.data = data;
-        this.edge = data.edge;
+  constructor(data: BTEQueryObject) {
+    this.data = data;
+    this.edge = data.edge;
+  }
+
+  /**
+   * Create an object with key representing input, and value representing the output of API
+   */
+  pairInputWithAPIResponse() {
+    let input = generateCurie(this.edge.association.input_id, this.edge.input);
+    return {
+      [input]: [this.data.response],
+    };
+  }
+
+  /**
+   * Wrapper functions to transform API response before passing to JSON Transformer
+   * @return {Object} - key is curie representing input, value is an array of outputs.
+   */
+  wrap(res) {
+    if (Array.isArray(res)) {
+      res = { data: res };
     }
+    return res;
+  }
 
-    /**
-     * Create an object with key representing input, and value representing the output of API
-     */
-    pairInputWithAPIResponse() {
-        let input = generateCurie(this.edge.association.input_id, this.edge.input);
-        return {
-            [input]: [this.data.response]
-        }
+  /**
+   * Transform Individual JSON response into Biolink compatible format
+   * @param {Object} res - JSON response representing an output.
+   */
+  jsonTransform(res: JSONDoc | JSONDoc[]) {
+    res = transform(res, this.edge.response_mapping);
+    return res;
+  }
+
+  _updatePublications(res) {
+    if ("pubmed" in res) {
+      res.pubmed = toArray(res.pubmed);
+      res.publications = res.pubmed.map(item =>
+        typeof item === "string" && item.toUpperCase().startsWith("PMID:") ? item.toUpperCase() : "PMID:" + item,
+      );
+      delete res.pubmed;
     }
-
-    /**
-     * Wrapper functions to transform API response before passing to JSON Transformer
-     * @return {Object} - key is curie representing input, value is an array of outputs.
-     */
-    wrap(res) {
-        if (Array.isArray(res)) {
-            res = { data: res }
-        }
-        return res;
+    if ("pmc" in res) {
+      res.pmc = toArray(res.pmc);
+      res.publications = res.pmc.map(item =>
+        typeof item === "string" && item.toUpperCase().startsWith("PMC:") ? item.toUpperCase() : "PMC:" + item,
+      );
+      delete res.pmc;
     }
+    return res;
+  }
 
-    /**
-     * Transform Individual JSON response into Biolink compatible format
-     * @param {Object} res - JSON response representing an output.
-     */
-    jsonTransform(res: JSONDoc | JSONDoc[]) {
-        res = transform(res, this.edge.response_mapping);
-        return res;
+  _updateEdgeMetadata(res) {
+    res.$edge_metadata = {
+      ...this.edge.association,
+      trapi_qEdge_obj: this.edge.reasoner_edge,
+      filter: this.edge.filter,
+    };
+    return res;
+  }
+
+  _updateInput(res, input) {
+    debug(`input: ${input}`);
+    res.$input = {
+      original: typeof this.edge.original_input === "undefined" ? undefined : this.edge.original_input[input],
+      obj:
+        typeof this.edge.input_resolved_identifiers === "undefined" || typeof this.edge.original_input === "undefined"
+          ? undefined
+          : this.edge.input_resolved_identifiers[this.edge.original_input[input]],
+    };
+    if (this.edge.input_resolved_identifiers && res.$input.original === undefined && res.$input.obj === undefined) {
+      //try to find an equivalent ids object if the original input doesn't match (for ICEES)
+      for (let curie of Object.keys(this.edge.input_resolved_identifiers)) {
+        if (this.edge.input_resolved_identifiers[curie][0].curies.includes(input)) {
+          res.$input = {
+            original: curie,
+            obj: this.edge.input_resolved_identifiers[curie],
+          };
+          break;
+        }
+      }
     }
+    return res;
+  }
 
-    _updatePublications(res) {
-        if ("pubmed" in res) {
-            res.pubmed = toArray(res.pubmed);
-            res.publications = res.pubmed.map(item => (typeof item === "string" && item.toUpperCase().startsWith("PMID:")) ? item.toUpperCase() : "PMID:" + item);
-            delete res.pubmed;
-        }
-        if ("pmc" in res) {
-            res.pmc = toArray(res.pmc);
-            res.publications = res.pmc.map(item => (typeof item === "string" && item.toUpperCase().startsWith("PMC:")) ? item.toUpperCase() : "PMC:" + item);
-            delete res.pmc;
-        }
-        return res;
+  _removeNonEdgeData(res) {
+    delete res["@type"];
+    delete res[this.edge.association.output_id];
+    return res;
+  }
+
+  /**
+   * Add edge information into individual output JSON.
+   * @param {Object} res - JSON response representing an output.
+   */
+  async addEdgeInfo(input, res) {
+    if (res === undefined || Object.keys(res).length === 0) {
+        return [];
     }
+    res = this._updateEdgeMetadata(res);
+    res = this._updateInput(res, input);
+    const output_ids = this.extractOutputIDs(res);
 
-    _updateEdgeMetadata(res) {
-        res.$edge_metadata = {
-            ...this.edge.association,
-            trapi_qEdge_obj: this.edge.reasoner_edge,
-            filter: this.edge.filter
-        }
-        return res;
-    }
-
-    _updateInput(res, input) {
-        debug(`input: ${input}`)
-        res.$input = {
-            original: (typeof this.edge.original_input === "undefined") ? undefined : this.edge.original_input[input],
-            obj: (typeof this.edge.input_resolved_identifiers === "undefined" || typeof this.edge.original_input === "undefined") ? undefined : this.edge.input_resolved_identifiers[this.edge.original_input[input]]
-        }
-        if (this.edge.input_resolved_identifiers && res.$input.original === undefined && res.$input.obj === undefined) { //try to find an equivalent ids object if the original input doesn't match (for ICEES)
-            for (let curie of Object.keys(this.edge.input_resolved_identifiers)) {
-                if (this.edge.input_resolved_identifiers[curie][0].curies.includes(input)) {
-                    res.$input = {
-                        original: curie,
-                        obj: this.edge.input_resolved_identifiers[curie]
-                    };
-                    break;
-                }
-            }
-        }
-        return res;
-    }
-
-    _removeNonEdgeData(res) {
-        delete res["@type"];
-        delete res[this.edge.association.output_id];
-        return res;
-    }
-
-    /**
-     * Add edge information into individual output JSON.
-     * @param {Object} res - JSON response representing an output.
-     */
-    addEdgeInfo(input, res) {
-        if (res === undefined || (Object.keys(res).length === 0)) {
-            return [];
-        }
-        res = this._updateEdgeMetadata(res);
-        res = this._updateInput(res, input);
-        const output_ids = this.extractOutputIDs(res);
-        let result = output_ids.map(item => {
-            let copy_res = _.cloneDeep(res);
-            copy_res.$edge_metadata = res.$edge_metadata;
-            copy_res.$output = {
-                original: item
-            }
-            copy_res = this._removeNonEdgeData(copy_res);
-            copy_res = this._updatePublications(copy_res);
-            return copy_res;
+    const setImmediatePromise = () => {
+        return new Promise((resolve: any) => {
+            setImmediate(() => resolve());
         });
-        return result;
-    }
+    };
 
-    /**
-     * Main function to transform API response
-     */
-    transform() {
-        let result = [];
-        let responses = this.pairInputWithAPIResponse();
-        for (let curie of Object.keys(responses)) {
-            if (Array.isArray(responses[curie]) && responses[curie].length > 0) {
-                responses[curie].map(item => {
-                    item = this.wrap(item);
-                    item = this.jsonTransform(item);
-                    for (let predicate of Object.keys(item)) {
-                        if (Array.isArray(item[predicate]) && item[predicate].length > 0) {
-                            item[predicate].map(rec => {
-                                rec = this.addEdgeInfo(curie, rec);
-                                result = [...result, ...rec];
-                            });
-                        } else {
-                            result = [...result, ...this.addEdgeInfo(curie, item[predicate])];
-                        }
-                    }
-                });
-            }
-        };
-        return result;
-    }
-    /**
-     * Retrieve all output IDs.
-     * @param {Object} res - JSON response representing an output.
-     */
-    extractOutputIDs(res) {
-        const output_id_type = this.edge.association.output_id;
-        if (!(output_id_type in res)) {
-            return [];
+    let result = await async.mapSeries(output_ids, async item => {
+        let blockingSince = Date.now();
+
+        let copy_res = _.cloneDeep(res);
+        if (blockingSince + 3 < Date.now()) {
+            await setImmediatePromise();
+            blockingSince = Date.now();
         }
-        res[output_id_type] = toArray(res[output_id_type]);
-        return res[output_id_type].map(item => generateCurie(output_id_type, item));
+        copy_res.$edge_metadata = res.$edge_metadata;
+        copy_res.$output = {
+            original: item,
+        };
+        copy_res = this._removeNonEdgeData(copy_res);
+        copy_res = this._updatePublications(copy_res);
+        return copy_res;
+    });
+    return result;
+  }
+
+  /**
+   * Main function to transform API response
+   */
+  async transform() {
+    let result = [];
+    let responses = this.pairInputWithAPIResponse();
+
+    await async.eachSeries(Object.keys(responses), async curie => {
+    if (Array.isArray(responses[curie]) && responses[curie].length > 0) {
+        await async.eachSeries(responses[curie], async item => {
+        item = this.wrap(item);
+        item = this.jsonTransform(item);
+        await async.eachSeries(Object.keys(item), async predicate => {
+            if (Array.isArray(item[predicate]) && item[predicate].length > 0) {
+            await async.eachSeries(item[predicate], async (rec: any[]) => {
+                rec = await this.addEdgeInfo(curie, rec);
+                result.push(...rec);
+            });
+            } else {
+                result.push(...(await this.addEdgeInfo(curie, item[predicate])));
+            }
+        });
+        });
     }
+    });
+    return result;
+  }
+
+  /**
+   * Retrieve all output IDs.
+   * @param {Object} res - JSON response representing an output.
+   */
+  extractOutputIDs(res) {
+    const output_id_type = this.edge.association.output_id;
+    if (!(output_id_type in res)) {
+      return [];
+    }
+    res[output_id_type] = toArray(res[output_id_type]);
+    return res[output_id_type].map(item => generateCurie(output_id_type, item));
+  }
 }

--- a/src/transformers/trapi_transformer.ts
+++ b/src/transformers/trapi_transformer.ts
@@ -39,7 +39,7 @@ export default class TRAPITransformer extends BaseTransformer {
 
     }
 
-    transform() {
+    async transform() {
         const edgeBindings = this._getUniqueEdges();
         return Object.keys(edgeBindings).map(edge => {
             const edgeInfo = this._getEdgeInfo(edge);


### PR DESCRIPTION
*(partially addresses https://github.com/biothings/BioThings_Explorer_TRAPI/issues/263)*

This PR makes response transformation happen asynchronously, and more importantly, yields to the event loop during operation if it takes more than 3ms, allowing new requests to be polled. 

This makes longer queries take more time (somewhere between 5-20% longer in basic testing), but keeps the server responsive while these queries are processed. Previously in small-scale testing, while handling even one long query with many IDs, the server would take 20+ seconds to respond to `http://localhost:3000/v1/smartapi/59dce17363dce279d389100834e43648/meta_knowledge_graph`, while after this change under the same conditions it takes on the order of 100-300 of ms. 

This change won't fully fix the issue but it should at least keep the server from going down and allow shorter queries to process much more quickly while longer queries take their time rather than bogging down response time.

Requires https://github.com/biothings/call-apis.js/pull/32