### PR TITLE
Use SETIMMEDIATE_TIME to set timing of yield to event loop

### DIFF
--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -125,9 +125,9 @@ export default class BaseTransformer {
             let blockingSince = Date.now();
 
             let copy_res = _.cloneDeep(res);
-            if (blockingSince + 3 < Date.now()) {
-                await setImmediatePromise();
-                blockingSince = Date.now();
+            if (blockingSince + (parseInt(process.env.SETIMMEDIATE_TIME) || 3) < Date.now()) {
+              await setImmediatePromise();
+              blockingSince = Date.now();
             }
             copy_res.$edge_metadata = res.$edge_metadata;
             copy_res.$output = {


### PR DESCRIPTION
 *(continuation of https://github.com/biothings/api-respone-transform.js/pull/16)*

This PR allows and env variable `SETIMMEDIATE_TIME` to be used to override the default 3ms wait before yielding to the event loop while performing `cloneDeep()`