### PR TITLE
Remove use of cloneDeep for response transform

### DIFF
--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -111,32 +111,33 @@ export default class BaseTransformer {
         if (res === undefined || Object.keys(res).length === 0) {
             return [];
         }
-        res = this._updateEdgeMetadata(res);
-        res = this._updateInput(res, input);
-        const output_ids = this.extractOutputIDs(res);
 
         const setImmediatePromise = () => {
             return new Promise((resolve: any) => {
                 setImmediate(() => resolve());
             });
         };
+        // blocking timer is kept because this part still blocks w/o it
+        let blockingSince = Date.now();
+
+        res = this._updateEdgeMetadata(res);
+        res = this._updateInput(res, input);
+        res = this._removeNonEdgeData(res);
+        res = this._updatePublications(res);
+        const output_ids = this.extractOutputIDs(res);
 
         let result = await async.mapSeries(output_ids, async item => {
-            let blockingSince = Date.now();
-
-            let copy_res = _.cloneDeep(res);
-            if (blockingSince + (parseInt(process.env.SETIMMEDIATE_TIME) || 3) < Date.now()) {
-              await setImmediatePromise();
-              blockingSince = Date.now();
-            }
-            copy_res.$edge_metadata = res.$edge_metadata;
+            let copy_res = { ...res };
             copy_res.$output = {
                 original: item,
             };
-            copy_res = this._removeNonEdgeData(copy_res);
-            copy_res = this._updatePublications(copy_res);
             return copy_res;
         });
+        // timer default set to 1ms because this function *should* usually take <1ms
+        if (blockingSince + (parseInt(process.env.SETIMMEDIATE_TIME) || 1) < Date.now()) {
+            await setImmediatePromise();
+            blockingSince = Date.now();
+        }
         return result;
     }
 


### PR DESCRIPTION
This should further improve responsiveness/performance. 

Note: the default wait time before yielding to the async event loop has been reduced to 1ms for this function specifically, as it should usually take less than 1ms to complete, however this is now across the whole function instead of per iteration within the function.

Warning for the future: results now use a fair amount of object references instead of being cloned, so don't make changes to any part of results coming out of `transform()` except for `res.$output`.