### PR TITLE
Handle input curies from templated APIEdge

### DIFF
--- a/src/transformers/biothings_transformer.ts
+++ b/src/transformers/biothings_transformer.ts
@@ -18,7 +18,10 @@ export default class BioThingsTransformer extends BaseTransformer {
             });
             return res;
         } else {
-            let _input = generateCurie(this.edge.association.input_id, this.edge.input);
+            let _input = generateCurie(
+                this.edge.association.input_id,
+                this.edge.input.hasOwnProperty('queryInputs') ? this.edge.input["queryInputs"] : this.edge.input as string
+            );
             return { [_input]: [this.data["response"]] }
         }
 

--- a/src/transformers/biothings_transformer.ts
+++ b/src/transformers/biothings_transformer.ts
@@ -18,11 +18,7 @@ export default class BioThingsTransformer extends BaseTransformer {
             });
             return res;
         } else {
-            let _input = generateCurie(
-                this.edge.association.input_id,
-                this.edge.input.hasOwnProperty('queryInputs') ? this.edge.input["queryInputs"] : this.edge.input as string
-            );
-            return { [_input]: [this.data["response"]] }
+            return super.pairCurieWithAPIResponse();
         }
 
     }

--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -24,7 +24,10 @@ export default class BaseTransformer {
      * Create an object with key representing input, and value representing the output of API
      */
     pairCurieWithAPIResponse() {
-        let input = generateCurie(this.edge.association.input_id, this.edge.input);
+        let input = generateCurie(
+            this.edge.association.input_id,
+            this.edge.input.hasOwnProperty('queryInputs') ? this.edge.input["queryInputs"] : this.edge.input as string
+        );
         return {
             [input]: [this.data.response],
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,8 +35,12 @@ interface SmartAPIKGOperationObject {
     tags?: string[];
 }
 
+interface templatedInput {
+    queryInputs: any;
+}
+
 export interface BTEKGOperationObject extends SmartAPIKGOperationObject {
-    input: string | string[];
+    input: string | string[] | templatedInput;
     reasoner_edge?: any;
     filter?: string;
     original_input?: object;


### PR DESCRIPTION
APIs using templated annotations and non-BioThings transformers fail due to a difference in APIEdge input structure. This PR handles this case (in`transformer.pairCurieWithAPIResponse()`, for both `BaseTransformer` and a fallback behavior in `BioThingsTransformer`).