### PR TITLE
A small multitude of updates

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -18,12 +18,12 @@ class RecordNode {
   makeFakeInfo(node: FrozenNode | VerboseFrozenNode | MinimalFrozenNode): NodeNormalizerResultObj {
     return {
         primaryID: node.curie,
-        equivalentIDs: node.equivalentCuries,
+        equivalentIDs: node.equivalentCuries ?? [],
         label: node.label,
         labelAliases: node.names,
         primaryTypes: [node.semanticType],
-        semanticTypes: node.semanticTypes,
-        attributes: node.attributes,
+        semanticTypes: node.semanticTypes ?? [],
+        attributes: node.attributes ?? {},
       };
   }
 

--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -85,20 +85,20 @@ export default class BaseTransformer {
         //debug(`input: ${input}`);
         let subject = {
             original: typeof this.edge.original_input === "undefined" ? undefined : this.edge.original_input[subjectCurie],
-            normalizedInfo:
-                typeof this.edge.input_resolved_identifiers === "undefined" || typeof this.edge.original_input === "undefined"
-                ? undefined
-                : this.edge.input_resolved_identifiers[this.edge.original_input[subjectCurie]],
+            // normalizedInfo:
+            //     typeof this.edge.input_resolved_identifiers === "undefined" || typeof this.edge.original_input === "undefined"
+            //     ? undefined
+            //     : this.edge.input_resolved_identifiers[this.edge.original_input[subjectCurie]],
         }
-        if (this.edge.input_resolved_identifiers && subject.original === undefined && subject.normalizedInfo === undefined) {
+        if (this.edge.input_resolved_identifiers && subject.original === undefined) {
             //try to find an equivalent ids object if the original input doesn't match (for ICEES)
             for (let curie of Object.keys(this.edge.input_resolved_identifiers)) {
-                if (this.edge.input_resolved_identifiers[curie][0].curies.includes(subjectCurie)) {
-                subject = {
-                    original: curie,
-                    normalizedInfo: this.edge.input_resolved_identifiers[curie],
-                };
-                break;
+                if (this.edge.input_resolved_identifiers[curie].equivalentIDs.includes(subjectCurie)) {
+                    subject = {
+                        original: curie,
+                        // normalizedInfo: this.edge.input_resolved_identifiers[curie],
+                    };
+                    break;
                 }
             }
         }
@@ -120,15 +120,6 @@ export default class BaseTransformer {
             return [];
         }
 
-        const setImmediatePromise = () => {
-            return new Promise((resolve: any) => {
-                setImmediate(() => resolve());
-            });
-        };
-        // blocking timer is kept because this part still blocks w/o it
-        let blockingSince = Date.now();
-
-
         // mappedResponse = this._updateEdgeMetadata(mappedResponse);
         const objectIDs = this.extractObjectIDs(mappedResponse);
         mappedResponse = this._removeNonEdgeData(mappedResponse);
@@ -142,11 +133,6 @@ export default class BaseTransformer {
         }
 
         let transformedRecords = await async.mapSeries(objectIDs, async (curie: string) => {
-            // timer default set to 1ms because this function *should* usually take <1ms
-            if (blockingSince + (parseInt(process.env.SETIMMEDIATE_TIME) || 1) < Date.now()) {
-                await setImmediatePromise();
-                blockingSince = Date.now();
-            }
 
             let copyRecord = {
                 ...frozenRecord,

--- a/src/transformers/trapi_transformer.ts
+++ b/src/transformers/trapi_transformer.ts
@@ -40,7 +40,7 @@ export default class TRAPITransformer extends BaseTransformer {
           mappedResponse: { "edge-attributes": [...edge.attributes] },
         };
 
-        if ("subject" in frozenRecord && "normalizedInfo" in frozenRecord["subject"] && !(typeof frozenRecord.subject.normalizedInfo === "undefined")) {
+        if ("subject" in frozenRecord) {
             return new Record(frozenRecord, this.config, this.edge.association, this.edge.reasoner_edge);
         }
 


### PR DESCRIPTION
This update has, due to time and overlapping of code touched by each feature, become a single amalgam update using one branch name across each module. As such, the changes across the whole update will be listed the same for each PR:

- Response from SRI resolver package has been refactored
- Record has been refactored to accommodate new resolved node structure
- Code across the modules has been refactored to use record instead of normalizedInfo where possible
- When calling APIs, raw responses are discarded as soon as transformed records are available
- Async handling has changed:
  - Responses are now kept 30 days instead of 7
  - Failed jobs are now kept for 1 day instead of being discarded immediately
  - Completed jobs are kept 90 days
  - Bull now uses the same redisClient system as the rest of BTE
  - Bull jobs are now executed in a thread, rather than a subprocess
  - Bull jobs are cancelled and marked failed after 2 hours of execution
- A Bull queue dashboard has been added at `/queues` endpoint
- redisClient now has a longer connection timeout, and a custom retry strategy
- some code has been moved to the edge manager for clarity
- BTE now considers records matching if they match a node original or primaryID that might somehow be missing from equivalentIDs, meaning fewer records are dropped in some circumstances
- Relevant tests have been updated