### PR TITLE
Publication refactor

### DIFF
--- a/__test__/base_transformer.test.ts
+++ b/__test__/base_transformer.test.ts
@@ -77,7 +77,7 @@ describe("test base transformer", () => {
     test("Test _updatePublications function if pmc id is prefixed", () => {
         const tf = new base_tf(input, {});
         const fake = {
-            ref_pmcid: "PMC:1233"
+            ref_pmcid: "PMCID:1233"
         }
         const res = tf._updatePublications(fake);
         expect(res).not.toHaveProperty('ref_pmcid');

--- a/__test__/base_transformer.test.ts
+++ b/__test__/base_transformer.test.ts
@@ -57,41 +57,41 @@ describe("test base transformer", () => {
     test("Test _updatePublications function if pubmed id is prefixed", () => {
         const tf = new base_tf(input, {});
         const fake = {
-            pubmed: "PMID:1233"
+            ref_pmid: "PMID:1233"
         }
         const res = tf._updatePublications(fake);
-        expect(res).not.toHaveProperty('pubmed');
+        expect(res).not.toHaveProperty('ref_pmid');
         expect(res.publications).toEqual(["PMID:1233"]);
     })
 
     test("Test _updatePublications function if pubmed id is NOT prefixed", () => {
         const tf = new base_tf(input, {});
         const fake = {
-            pubmed: 1233
+            ref_pmid: 1233
         }
         const res = tf._updatePublications(fake);
-        expect(res).not.toHaveProperty('pubmed');
+        expect(res).not.toHaveProperty('ref_pmid');
         expect(res.publications).toEqual(["PMID:1233"])
     })
 
     test("Test _updatePublications function if pmc id is prefixed", () => {
         const tf = new base_tf(input, {});
         const fake = {
-            pmc: "PMC:1233"
+            ref_pmcid: "PMC:1233"
         }
         const res = tf._updatePublications(fake);
-        expect(res).not.toHaveProperty('pmc');
-        expect(res.publications).toEqual(["PMC:1233"]);
+        expect(res).not.toHaveProperty('ref_pmcid');
+        expect(res.publications).toEqual(["PMCID:1233"]);
     })
 
     test("Test _updatePublications function if pmc id is NOT prefixed", () => {
         const tf = new base_tf(input, {});
         const fake = {
-            pmc: 123
+            ref_pmcid: 123
         }
         const res = tf._updatePublications(fake);
-        expect(res).not.toHaveProperty('pmc');
-        expect(res.publications).toEqual(["PMC:123"])
+        expect(res).not.toHaveProperty('ref_pmcid');
+        expect(res.publications).toEqual(["PMCID:123"])
     })
 
     test("Test extractObjectIDs function if output id type not in result", () => {

--- a/__test__/biothings_transformer.test.ts
+++ b/__test__/biothings_transformer.test.ts
@@ -58,7 +58,7 @@ describe("test biothings transformer", () => {
             let tf = new biothings_tf(input, {});
             let res = await tf.transform();
             expect(res).toHaveLength(27);
-            expect(res[0]).not.toHaveProperty('pubmed');
+            expect(res[0]).not.toHaveProperty('ref_pmid');
             expect(res[0]).toHaveProperty('publications', ["PMID:21873635"]);
         })
     })

--- a/src/transformers/biolink_transformer.ts
+++ b/src/transformers/biolink_transformer.ts
@@ -15,12 +15,18 @@ export default class BiolinkTransformer extends BaseTransformer {
                         rec['object'][prefix] = rec.object.id;
                     }
                 }
-                if (rec.publications === undefined || rec.publications.length === 0 || !(rec.publications[0]['id'].startsWith("PMID"))) {
+                if (rec.publications === undefined || rec.publications.length === 0) {
                     delete rec.publications
                 } else {
-                    rec.publications = rec.publications.map(pub => {
-                        return { "id": pub.id.split(':').slice(-1)[0] }
-                    })
+                    const oldPublications = rec.publications;
+                    rec.publications = [];
+                    for (let oldPub of oldPublications) {
+                        if (!oldPub?.id?.startsWith?.("PMID:")) {
+                            continue;
+                        }
+
+                        rec.publications.push({ id: oldPub.id.split(':').slice(-1)[0] });
+                    }
                 }
                 if (!("provided_by" in rec)) {
                     delete rec.provided_by

--- a/src/transformers/ctd_transformer.ts
+++ b/src/transformers/ctd_transformer.ts
@@ -7,8 +7,14 @@ export default class CTDTransformer extends BaseTransformer {
             if (typeof item.PubMedIDs === "string") {
                 item.PubMedIDs = item.PubMedIDs.split('|');
             }
+            if (typeof item.PubMedIds === "string") {
+                item.PubMedIds = item.PubMedIds.split('|');
+            }
             if (typeof item.DiseaseID === "string") {
                 item.DiseaseID = item.DiseaseID.split(':').slice(-1)[0];
+            }
+            if (typeof item.DiseaseId === "string") {
+                item.DiseaseId = item.DiseaseId.split(':').slice(-1)[0];
             }
             return item;
         });

--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -107,6 +107,11 @@ export default class BaseTransformer {
         for (let publicationType of publicationTypes) {
             if (publicationType.prop in mappedResponse) {
                 for (let publication of toArray(mappedResponse[publicationType.prop])) {
+                    // handle numbers
+                    if (typeof publication === "number") {
+                        publication = publication.toString();
+                    }
+
                     if (typeof publication !== "string" || publication.length === 0) {
                         continue;
                     }

--- a/src/transformers/transformer.ts
+++ b/src/transformers/transformer.ts
@@ -59,9 +59,9 @@ export default class BaseTransformer {
         }
 
         const publicationTypes = [
-            {prop: "ref_pmid", prefix: "PMID:", urls: ["http://www.ncbi.nlm.nih.gov/pubmed/", "http://europepmc.org/abstract/MED/"]},
+            {prop: "ref_pmid", prefix: "PMID:", urls: ["http://www.ncbi.nlm.nih.gov/pubmed/", "http://europepmc.org/abstract/MED/", "https://www.ncbi.nlm.nih.gov/pubmed/"]},
             {prop: "ref_pmcid", prefix: "PMCID:", urls: ["http://www.ncbi.nlm.nih.gov/pmc/articles/", "http://europepmc.org/articles/"]},
-            {prop: "ref_clinicaltrials", prefix: "clinicaltrials:", urls: ["https://clinicaltrials.gov/ct2/show/"]},
+            {prop: "ref_clinicaltrials", prefix: "clinicaltrials:", urls: ["https://clinicaltrials.gov/ct2/show/", "https://www.clinicaltrials.gov/ct2/show/"]},
             {prop: "ref_doi", prefix: "doi:", urls: ["https://doi.org/", "http://www.nejm.org/doi/full/", "https://www.tandfonline.com/doi/abs/", "http://onlinelibrary.wiley.com/doi/"]},
             {prop: "ref_isbn", prefix: "isbn:", urls: ["https://www.isbn-international.org/identifier/"]}
         ]


### PR DESCRIPTION
https://github.com/biothings/biothings_explorer/issues/677. Handles different types of publications. For URLs, if it starts with the URL string of a prefix, it is turned into a curie by stripping the URL part and then adding the prefix.

For publication strings with CURIE prefixes, it is checked if the prefix [with ":" so like "PMID:"] exists (in any casing), and if so, strip the prefix. Then just add the prefix back on the beginning of the string.

Current info that is being used for the prefixes:
- {prop: "ref_pmid", prefix: "PMID:", urls: ["http://www.ncbi.nlm.nih.gov/pubmed/", "http://europepmc.org/abstract/MED/"]},
- {prop: "ref_pmcid", prefix: "PMCID:", urls: ["http://www.ncbi.nlm.nih.gov/pmc/articles/", "http://europepmc.org/articles/"]},
- {prop: "ref_clinicaltrials", prefix: "clinicaltrials:", urls: ["https://clinicaltrials.gov/ct2/show/"]},
- {prop: "ref_doi", prefix: "doi:", urls: ["https://doi.org/", "http://www.nejm.org/doi/full/", "https://www.tandfonline.com/doi/abs/", "http://onlinelibrary.wiley.com/doi/"]},
- {prop: "ref_isbn", prefix: "isbn:", urls: ["https://www.isbn-international.org/identifier/"]}