### PR TITLE
Use KL/AT in record hash

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -455,6 +455,8 @@ export class Record {
           sourceA.resource_id.localeCompare(sourceB.resource_id),
         ).map(source => _.omit(source, ["source_record_urls"])),
       ),
+      this.knowledge_level,
+      this.agent_type
     ].join("-");
   }
 


### PR DESCRIPTION
This should fix cases where KL/AT values get string-concatenated when two edges otherwise match.